### PR TITLE
Use LinkedHashMap for deterministic iterations

### DIFF
--- a/src/main/java/com/github/pedrovgs/problem45/FindNthMostRepeatedElement.java
+++ b/src/main/java/com/github/pedrovgs/problem45/FindNthMostRepeatedElement.java
@@ -15,7 +15,7 @@
  */
 package com.github.pedrovgs.problem45;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -33,7 +33,7 @@ public class FindNthMostRepeatedElement {
   public int find(int[] numbers, int position) {
     validateInput(numbers, position);
     Integer result = null;
-    Map<Integer, Integer> counter = new HashMap<Integer, Integer>();
+    Map<Integer, Integer> counter = new LinkedHashMap<Integer, Integer>();
     for (int i : numbers) {
       if (counter.get(i) == null) {
         counter.put(i, 1);


### PR DESCRIPTION
Test `shouldFindNthMostRepeatedElement` is looking for the 2nd most repeated element in  `{ 1, 1, 2, 3, 4, 5, 2, 2, 2, 4, 4, 6, 7, 4, 9, 214, 4, 5, };` There are equal number of `1`s and `5`s. In the algorithm, it iterates on a `keySet` of a HashMap to find the nth repeated element. But HashMap does not guarantee any specific order of entries. Therefore, the assertion will fail if the iteration order differs.

This PR proposes to change the HashMap to LinkedHashMap for a deterministic iteration order (same as insertion order). This order is also same as expected by the test assertion: `assertEquals(1, result);`