### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,4 +17,4 @@ jobs:
         run: mvn checkstyle:checkstyle
 
       - name: Test
-        run: mvn install
+        run: mvn install -DdisableXmlReport=true


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report is generated but not used in CI. Because this surefire-report is not accessed after its generation. Hence, we propose to disable the generation of this surefire-report directory to save runtime.

The generation of this surefire-report can be restricted by simply adding -DdisableXmlReport=true
 with the mvn command
