### PR TITLE
Ignoring unnecessarily generated site directory

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
       - name: Check java checkstyle
-        run: mvn checkstyle:checkstyle
+        run: mvn checkstyle:check
 
       - name: Test
         run: mvn install


### PR DESCRIPTION
In our analysis, we observe that the target/site directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime. The generation of this directory can be disabled by simply adding checkstyle:check instead of checkstyle:checkstyle to the mvn command.