### PR TITLE
Add unit tests for BinaryNode, ListNode, and Pair; fix equals in ListNode

### DIFF
--- a/src/main/java/com/github/pedrovgs/linkedlist/ListNode.java
+++ b/src/main/java/com/github/pedrovgs/linkedlist/ListNode.java
@@ -15,6 +15,8 @@
  */
 package com.github.pedrovgs.linkedlist;
 
+import java.util.Objects;
+
 /**
  * Main class for linked list data structure. A linked list is a data structure consisting of a
  * group of nodes which together represent a sequence. Under the simplest form, each node is
@@ -57,7 +59,7 @@ public class ListNode<T> {
 
     if (!data.equals(listNode.data)) return false;
 
-    return true;
+    return Objects.equals(next, listNode.next);
   }
 
   @Override public int hashCode() {

--- a/src/test/java/com/github/pedrovgs/binarytree/BinaryNodeTest.java
+++ b/src/test/java/com/github/pedrovgs/binarytree/BinaryNodeTest.java
@@ -1,0 +1,131 @@
+package com.github.pedrovgs.binarytree;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BinaryNodeTest {
+
+    @Test
+    public void testEqualsSameObject() {
+        BinaryNode<Integer> node = new BinaryNode<>(1);
+        assertEquals(node, node); // this == o
+    }
+
+    @Test
+    public void testEqualsEqualObjectsWithoutChildren() {
+        BinaryNode<Integer> node1 = new BinaryNode<>(1);
+        BinaryNode<Integer> node2 = new BinaryNode<>(1);
+        assertEquals(node1, node2);
+    }
+
+    @Test
+    public void testEqualsEqualObjectsWithChildren() {
+        BinaryNode<Integer> node1 = new BinaryNode<>(1);
+        node1.setLeft(new BinaryNode<>(2));
+        node1.setRight(new BinaryNode<>(3));
+
+        BinaryNode<Integer> node2 = new BinaryNode<>(1);
+        node2.setLeft(new BinaryNode<>(2));
+        node2.setRight(new BinaryNode<>(3));
+
+        assertEquals(node1, node2);
+    }
+
+    @Test
+    public void testEqualsNull() {
+        BinaryNode<Integer> node = new BinaryNode<>(1);
+        assertNotEquals(node, null);
+    }
+
+    @Test
+    public void testEqualsDifferentClass() {
+        BinaryNode<Integer> node = new BinaryNode<>(1);
+        String other = "not a node";
+        assertNotEquals(node, other);
+    }
+
+    @Test
+    public void testNotEqualsDifferentData() {
+        BinaryNode<Integer> node1 = new BinaryNode<>(1);
+        BinaryNode<Integer> node2 = new BinaryNode<>(2);
+        assertNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testNotEqualsDifferentLeft() {
+        BinaryNode<Integer> node1 = new BinaryNode<>(1);
+        node1.setLeft(new BinaryNode<>(2));
+
+        BinaryNode<Integer> node2 = new BinaryNode<>(1);
+        node2.setLeft(new BinaryNode<>(3));
+
+        assertNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testNotEqualsDifferentRight() {
+        BinaryNode<Integer> node1 = new BinaryNode<>(1);
+        node1.setRight(new BinaryNode<>(2));
+
+        BinaryNode<Integer> node2 = new BinaryNode<>(1);
+        node2.setRight(new BinaryNode<>(3));
+
+        assertNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testHashCodeEqualObjectsWithoutChildren() {
+        BinaryNode<Integer> node1 = new BinaryNode<>(1);
+        BinaryNode<Integer> node2 = new BinaryNode<>(1);
+        assertEquals(node1.hashCode(), node2.hashCode());
+    }
+
+    @Test
+    public void testHashCodeEqualObjectsWithChildren() {
+        BinaryNode<Integer> node1 = new BinaryNode<>(1);
+        node1.setLeft(new BinaryNode<>(2));
+        node1.setRight(new BinaryNode<>(3));
+
+        BinaryNode<Integer> node2 = new BinaryNode<>(1);
+        node2.setLeft(new BinaryNode<>(2));
+        node2.setRight(new BinaryNode<>(3));
+
+        assertEquals(node1.hashCode(), node2.hashCode());
+    }
+
+    @Test
+    public void testHashCodeConsistency() {
+        BinaryNode<Integer> node = new BinaryNode<>(42);
+        int h1 = node.hashCode();
+        int h2 = node.hashCode();
+        assertEquals(h1, h2);
+    }
+
+    @Test
+    public void testBinaryNodeSetAndGetData() {
+        BinaryNode<Integer> node = new BinaryNode<>(1);
+        node.setRight(new BinaryNode<>(2));
+        node.setLeft(new BinaryNode<>(3));
+
+        assertEquals(1, (int) node.getData());
+        assertEquals(2, (int) node.getRight().getData());
+        assertEquals(3, (int) node.getLeft().getData());
+    }
+
+    @Test
+    public void testBinaryNodeToString() {
+        BinaryNode<String> node = new BinaryNode<>("Hello World");
+        String expected = "BinaryNode{data=Hello World}";
+        assertEquals(expected, node.toString());
+    }
+
+    @Test
+    public void testHasChildren() {
+        BinaryNode<Integer> node = new BinaryNode<>(1);
+        node.setRight(new BinaryNode<>(2));
+
+        assertTrue(node.hasRight());
+        assertFalse(node.hasLeft());
+    }
+}

--- a/src/test/java/com/github/pedrovgs/linkedlist/ListNodeTest.java
+++ b/src/test/java/com/github/pedrovgs/linkedlist/ListNodeTest.java
@@ -1,0 +1,102 @@
+package com.github.pedrovgs.linkedlist;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ListNodeTest {
+
+    @Test
+    public void testEqualsSameObject() {
+        ListNode<Integer> node = new ListNode<>(1);
+        assertEquals(node, node);
+    }
+
+    @Test
+    public void testEqualsEqualObjects() {
+        ListNode<Integer> node1 = new ListNode<>(1);
+        ListNode<Integer> node2 = new ListNode<>(1);
+        assertEquals(node1, node2);
+    }
+
+    @Test
+    public void testEqualsWithNextEqual() {
+        ListNode<Integer> node1 = new ListNode<>(1);
+        node1.setNext(new ListNode<>(2));
+
+        ListNode<Integer> node2 = new ListNode<>(1);
+        node2.setNext(new ListNode<>(2));
+
+        assertEquals(node1, node2);
+    }
+
+    @Test
+    public void testNotEqualsDifferentData() {
+        ListNode<Integer> node1 = new ListNode<>(1);
+        ListNode<Integer> node2 = new ListNode<>(2);
+        assertNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testNotEqualsDifferentNext() {
+        ListNode<Integer> node1 = new ListNode<>(1);
+        node1.setNext(new ListNode<>(2));
+
+        ListNode<Integer> node2 = new ListNode<>(1);
+        node2.setNext(new ListNode<>(3));
+
+        assertNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testNotEqualsNull() {
+        ListNode<Integer> node = new ListNode<>(1);
+        assertNotEquals(node, null);
+    }
+
+    @Test
+    public void testNotEqualsDifferentClass() {
+        ListNode<Integer> node = new ListNode<>(1);
+        String other = "not a node";
+        assertNotEquals(node, other);
+    }
+
+    @Test
+    public void testHashCodeEqualObjects() {
+        ListNode<Integer> node1 = new ListNode<>(1);
+        ListNode<Integer> node2 = new ListNode<>(1);
+        assertEquals(node1.hashCode(), node2.hashCode());
+    }
+
+    @Test
+    public void testHashCodeConsistency() {
+        ListNode<Integer> node = new ListNode<>(42);
+        int h1 = node.hashCode();
+        int h2 = node.hashCode();
+        assertEquals(h1, h2);
+    }
+
+    @Test
+    public void testToStringSingleNode() {
+        ListNode<Integer> node = new ListNode<>(1);
+        String expected = "ListNode{data=1, next=null}";
+        assertEquals(expected, node.toString());
+    }
+
+    @Test
+    public void testToStringTwoNodes() {
+        ListNode<Integer> node = new ListNode<>(1);
+        node.setNext(new ListNode<>(2));
+        String expected = "ListNode{data=1, next=ListNode{data=2, next=null}}";
+        assertEquals(expected, node.toString());
+    }
+
+    @Test
+    public void testToStringChain() {
+        ListNode<Integer> node = new ListNode<>(1);
+        node.setNext(new ListNode<>(2));
+        node.getNext().setNext(new ListNode<>(3));
+        String expected = "ListNode{data=1, next=ListNode{data=2, next=ListNode{data=3, next=null}}}";
+        assertEquals(expected, node.toString());
+    }
+}

--- a/src/test/java/com/github/pedrovgs/pair/PairTest.java
+++ b/src/test/java/com/github/pedrovgs/pair/PairTest.java
@@ -1,0 +1,57 @@
+package com.github.pedrovgs.pair;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PairTest {
+
+    @Test
+    public void testEqualsSameObject() {
+        Pair<Integer, String> pair = new Pair<>(1, "one");
+        assertEquals(pair, pair);
+    }
+
+    @Test
+    public void testEqualsEqualObjects() {
+        Pair<Integer, String> p1 = new Pair<>(1, "one");
+        Pair<Integer, String> p2 = new Pair<>(1, "one");
+        assertEquals(p1, p2);
+        assertEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    @Test
+    public void testNotEqualsDifferentA() {
+        Pair<Integer, String> p1 = new Pair<>(1, "one");
+        Pair<Integer, String> p2 = new Pair<>(2, "one");
+        assertNotEquals(p1, p2);
+    }
+
+    @Test
+    public void testNotEqualsDifferentB() {
+        Pair<Integer, String> p1 = new Pair<>(1, "one");
+        Pair<Integer, String> p2 = new Pair<>(1, "two");
+        assertNotEquals(p1, p2);
+    }
+
+    @Test
+    public void testNotEqualsNull() {
+        Pair<Integer, String> p1 = new Pair<>(1, "one");
+        assertNotEquals(p1, null);
+    }
+
+    @Test
+    public void testNotEqualsDifferentClass() {
+        Pair<Integer, String> p1 = new Pair<>(1, "one");
+        String other = "something";
+        assertNotEquals(p1, other);
+    }
+
+    @Test
+    public void testHashCodeConsistency() {
+        Pair<Integer, String> pair = new Pair<>(42, "answer");
+        int h1 = pair.hashCode();
+        int h2 = pair.hashCode();
+        assertEquals(h1, h2);
+    }
+}


### PR DESCRIPTION
Created comprehensive unit tests:

- BinaryNodeTest
- ListNodeTest
- PairTest

During test development, discovered that ListNode.equals did not compare the next field.
Refactored ListNode.equals (and hashCode) to include next comparison for correctness.